### PR TITLE
Playerr- fix conflict in player movement and truck 

### DIFF
--- a/MPGD-Game/Assets/Player/PlayerScripts/PlayerMovement.cs
+++ b/MPGD-Game/Assets/Player/PlayerScripts/PlayerMovement.cs
@@ -64,7 +64,6 @@ public class PlayerMovement : MonoBehaviour
         StartScene,
         PlayScene,
         DialogueScene
-
     };
     public GameState currentState = GameState.StartScene;
 
@@ -110,6 +109,7 @@ public class PlayerMovement : MonoBehaviour
                 Cursor.visible = true;
                 break;
         }
+
     }
     
     //Set the StartButton to connect here, which change the GameState after clicking:
@@ -134,6 +134,7 @@ public class PlayerMovement : MonoBehaviour
             updateCursorState();  // Reapply the cursor state when the game regains focus
         }
     }
+
 
     void Update()
     {

--- a/MPGD-Game/Assets/Scripts/Inventory/Trunk.cs
+++ b/MPGD-Game/Assets/Scripts/Inventory/Trunk.cs
@@ -32,15 +32,15 @@ public class Trunk : MonoBehaviour
             {
                 if (!inventory.activeSelf)
                 {
-                    inventory.SetActive(true);
-                    InventoryManager.Instance.ListItems();
+                    // inventory.SetActive(true);
+                    // InventoryManager.Instance.ListItems();
+                    OpenInventory();
                 }
                 else
                 {
-                    inventory.SetActive(false);
-                    InventoryManager.Instance.CleanContent();
                     //inventory.SetActive(false);
                     //InventoryManager.Instance.CleanContent();
+                    CloseInventory();
                 }
             }
         }
@@ -52,6 +52,32 @@ public class Trunk : MonoBehaviour
             }
         }
     }
+    // Open inventory and update game state
+    private void OpenInventory()
+    {
+        inventory.SetActive(true); // Show the inventory UI
+        InventoryManager.Instance.ListItems(); // Populate the inventory UI with items
 
+        // Lock the cursor and make it visible when inventory is opened
+        Cursor.lockState = CursorLockMode.None; // Unlock cursor
+        Cursor.visible = true; // Make cursor visible
+
+        // Disable player movement and other gameplay interactions (optional)
+        //PlayerMovement.Instance.DisableMovement(); // Assuming PlayerMovement has a DisableMovement method
+    }
+
+    // Close inventory and update game state
+    private void CloseInventory()
+    {
+        inventory.SetActive(false); // Hide the inventory UI
+        InventoryManager.Instance.CleanContent(); // Clean up the inventory UI
+
+        // Lock the cursor and hide it when inventory is closed
+        Cursor.lockState = CursorLockMode.Locked; // Lock cursor back to the center
+        Cursor.visible = false; // Hide cursor
+
+        // Re-enable player movement and other gameplay interactions (optional)
+        //PlayerMovement.Instance.EnableMovement(); // Assuming PlayerMovement has an EnableMovement method
+    }
 
 }

--- a/MPGD-Game/Assets/Scripts/Inventory/Trunk.cs
+++ b/MPGD-Game/Assets/Scripts/Inventory/Trunk.cs
@@ -39,6 +39,8 @@ public class Trunk : MonoBehaviour
                 {
                     inventory.SetActive(false);
                     InventoryManager.Instance.CleanContent();
+                    //inventory.SetActive(false);
+                    //InventoryManager.Instance.CleanContent();
                 }
             }
         }


### PR DESCRIPTION
update the player movement, the gamestate without the inventory trunk, so the cursor doesn't need to consider the condition here now, only focus on the startScene, GameScene, and maybe dialogueScene, 

Still need to fix the Dialogue cursor conditions.